### PR TITLE
Portability fixes

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -35,7 +35,7 @@ libxlsreader_la_SOURCES = \
 	src/xls.c
 
 libxlsreader_la_LDFLAGS = -version-info $(VERSION_INFO) $(LIBXLS_LIBS) @EXTRA_LDFLAGS@
-libxlsreader_la_CFLAGS = -Wall -Wextra -Wstrict-prototypes -Wno-unused-parameter -Werror -pedantic-errors
+libxlsreader_la_CFLAGS = -Wall -Wextra -Wstrict-prototypes -Wno-unused-parameter -pedantic-errors
 
 if FUZZER_ENABLED
 libxlsreader_la_CFLAGS += -fsanitize=fuzzer-no-link -fsanitize=address
@@ -62,6 +62,6 @@ EXTRA_PROGRAMS = fuzz_xls
 nodist_EXTRA_fuzz_xls_SOURCES = dummy.cxx
 
 fuzz_xls_SOURCES = fuzz/fuzz_xls.c
-fuzz_xls_CFLAGS = -Wall -Werror -pedantic-errors -std=c99
+fuzz_xls_CFLAGS = -Wall -pedantic-errors -std=c99
 fuzz_xls_LDADD = libxlsreader.la @LIB_FUZZING_ENGINE@
 fuzz_xls_LDFLAGS = -static

--- a/src/xlstool.c
+++ b/src/xlstool.c
@@ -220,7 +220,11 @@ static char* unicode_decode_iconv(const char *s, size_t len, size_t *newlen, con
             out_ptr = outbuf;
             while(inlenleft)
             {
+#if defined(__NetBSD__) || defined(__sun)
+                st = iconv(ic, &src_ptr, &inlenleft, (char **)&out_ptr,(size_t *) &outlenleft);
+#else
                 st = iconv(ic, (char **)&src_ptr, &inlenleft, (char **)&out_ptr,(size_t *) &outlenleft);
+#endif
                 if(st == (size_t)(-1))
                 {
                     if(errno == E2BIG)

--- a/src/xlstool.c
+++ b/src/xlstool.c
@@ -124,7 +124,7 @@ static const DWORD colors[] =
 void dumpbuf(BYTE* fname,long size,BYTE* buf)
 {
     FILE *f = fopen((char *)fname, "wb");
-    fwrite (buf, 1, size, f);
+    (void)fwrite (buf, 1, size, f);
     fclose(f);
 
 }


### PR DESCRIPTION
Thanks again for your work on this project. Here are two patches addressing build warnings in NetBSD and CentOS 6, as well as a suggestion to remove -Wall because it makes the build fragile, especially on somewhat more exotic environments.