### PR TITLE
Support NetBSD's iconv() prototype

### DIFF
--- a/src/xlstool.c
+++ b/src/xlstool.c
@@ -220,7 +220,11 @@ static char* unicode_decode_iconv(const char *s, size_t len, size_t *newlen, con
             out_ptr = outbuf;
             while(inlenleft)
             {
+#if defined(__NetBSD__) || defined(__sun)
+                st = iconv(ic, &src_ptr, &inlenleft, (char **)&out_ptr,(size_t *) &outlenleft);
+#else
                 st = iconv(ic, (char **)&src_ptr, &inlenleft, (char **)&out_ptr,(size_t *) &outlenleft);
+#endif
                 if(st == (size_t)(-1))
                 {
                     if(errno == E2BIG)


### PR DESCRIPTION
This fixes a warning when building on NetBSD where the prototype is
slightly different.

Split from PR #41.