### PR TITLE
Fix off-by-one in double byteswapping.

### DIFF
--- a/src/endian.c
+++ b/src/endian.c
@@ -87,7 +87,7 @@ void xlsConvertDouble(unsigned char *d)
         for (i=0; i<4; i++)
         {
             t = d[7-i];
-            d[8-i] = d[i];
+            d[7-i] = d[i];
             d[i] = t;
         }
     }


### PR DESCRIPTION
This fixes several failures in readxl on big-endian systems (e.g., [s390x](https://kojipkgs.fedoraproject.org//work/tasks/4926/33324926/build.log)).