### PR TITLE
Make C++ test conditional on having a C++11 compiler

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -22,6 +22,7 @@ addons:
   homebrew:
     packages:
     - gettext
+    - autoconf-archive
 
 matrix:
   exclude:

--- a/Makefile.am
+++ b/Makefile.am
@@ -16,8 +16,14 @@ nobase_include_HEADERS = \
 	include/libxls/xlstool.h
 
 bin_PROGRAMS = xls2csv
-noinst_PROGRAMS = test_libxls test2_libxls test_cpp
+noinst_PROGRAMS = test_libxls test2_libxls
 noinst_HEADERS = cplusplus/XlsReader.h
+check_PROGRAMS = test_libxls test2_libxls
+
+if HAVE_CXX11
+noinst_PROGRAMS += test_cpp
+check_PROGRAMS += test_cpp
+endif
 
 dist_man1_MANS = man/xls2csv.man
 
@@ -50,10 +56,11 @@ test_libxls_LDADD = libxlsreader.la
 test2_libxls_SOURCES = test/test2.c
 test2_libxls_LDADD = libxlsreader.la
 
+if HAVE_CXX11
 test_cpp_SOURCES = cplusplus/main.cpp cplusplus/XlsReader.cpp
 test_cpp_LDADD = libxlsreader.la
+endif
 
-check_PROGRAMS = test_libxls test2_libxls test_cpp
 TESTS = test_libxls
 
 EXTRA_DIST = README.md LICENSE test/files/test2.xls

--- a/appveyor.yml
+++ b/appveyor.yml
@@ -23,12 +23,14 @@ build_script:
       if ($env:TOOLCHAIN -eq "msys2")
       {
         $env:MSYSTEM="MINGW64"
+        C:\msys64\usr\bin\bash -l -c "pacman -S --noconfirm autoconf-archive"
         C:\msys64\usr\bin\bash -l -c "cd /c/projects/libxls && ./bootstrap"
         C:\msys64\usr\bin\bash -l -c "cd /c/projects/libxls && ./configure"
         C:\msys64\usr\bin\bash -l -c "cd /c/projects/libxls && make"
       }
       else
       {
+        C:\cygwin64\setup-x86_64.exe -qP autoconf-archive
         C:\cygwin64\bin\sh -lc "cd /cygdrive/c/projects/libxls && ./bootstrap"
         C:\cygwin64\bin\sh -lc "cd /cygdrive/c/projects/libxls && ./configure"
         C:\cygwin64\bin\sh -lc "cd /cygdrive/c/projects/libxls && make"

--- a/configure.ac
+++ b/configure.ac
@@ -33,7 +33,14 @@ AC_PROG_INSTALL
 AC_PROG_CC
 AC_PROG_CC_C99
 AC_PROG_CXX
-AX_CXX_COMPILE_STDCXX_11
+AX_CXX_COMPILE_STDCXX_11([], [optional])
+
+AS_IF([test "x$HAVE_CXX11" != x1], [
+    AC_MSG_NOTICE([---])
+    AC_MSG_NOTICE([No C++11 support, will skip C++ tests.])
+    AC_MSG_NOTICE([---])
+])
+AM_CONDITIONAL([HAVE_CXX11], [test x$HAVE_CXX11 = x1])
 
 AC_CHECK_FUNCS([strdup])
 AC_CHECK_HEADERS([wchar.h])


### PR DESCRIPTION
Ancient but supported platforms like RHEL 6 ship a version of GCC that
doesn't support C++11 causing ./configure to fail on that check. But
since C++ is only used for cpp_test we can make it conditional on having
a proper compiler and skip it otherwise.