### PR TITLE
[documentation] fix markdown language tag in README

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,7 +30,7 @@ Changes to libxls since 1.4:
 
 The [C API](include/xls.h) is pretty simple, this will get you started:
 
-```{C}
+```c
 xls_error_t error = LIBXLS_OK;
 xlsWorkBook *wb = xls_open_file("/path/to/finances.xls", "UTF-8", &error);
 if (wb == NULL) {


### PR DESCRIPTION
A very simple change but

This makes the sample C code better to look at in GitHub

#### Current  
![sssqsq](https://user-images.githubusercontent.com/10649516/73036214-cda5f780-3e85-11ea-8760-3582484f9be9.PNG)

#### Proposed  
![ssssq](https://user-images.githubusercontent.com/10649516/73036100-5708fa00-3e85-11ea-9940-c448aeb2919b.PNG)
