### PR TITLE
Improve decoding of non-Unicode files [WIP]

### DIFF
--- a/Makefile.am
+++ b/Makefile.am
@@ -10,6 +10,7 @@ nobase_include_HEADERS = \
 	include/libxls/brdb.c.h	\
 	include/libxls/brdb.h \
 	include/libxls/endian.h	\
+	include/libxls/locale.h	\
 	include/libxls/ole.h \
 	include/libxls/xlsstruct.h \
 	include/libxls/xlstypes.h \
@@ -39,6 +40,7 @@ xls2csv_LDADD = libxlsreader.la
 libxlsreader_la_SOURCES = \
 	src/xlstool.c \
 	src/endian.c \
+	src/locale.c \
 	src/ole.c \
 	src/xls.c
 

--- a/configure.ac
+++ b/configure.ac
@@ -43,7 +43,7 @@ AS_IF([test "x$HAVE_CXX11" != x1], [
 AM_CONDITIONAL([HAVE_CXX11], [test x$HAVE_CXX11 = x1])
 
 AC_CHECK_FUNCS([strdup])
-AC_CHECK_HEADERS([wchar.h])
+AC_CHECK_HEADERS([wchar.h xlocale.h])
 AC_FUNC_MALLOC
 AC_FUNC_REALLOC
 AC_TYPE_SIZE_T

--- a/configure.ac
+++ b/configure.ac
@@ -42,7 +42,7 @@ AS_IF([test "x$HAVE_CXX11" != x1], [
 ])
 AM_CONDITIONAL([HAVE_CXX11], [test x$HAVE_CXX11 = x1])
 
-AC_CHECK_FUNCS([strdup])
+AC_CHECK_FUNCS([strdup wcstombs_l])
 AC_CHECK_HEADERS([wchar.h xlocale.h])
 AC_FUNC_MALLOC
 AC_FUNC_REALLOC

--- a/include/libxls/locale.h
+++ b/include/libxls/locale.h
@@ -1,8 +1,7 @@
 #ifdef HAVE_XLOCALE_H
 #include <xlocale.h>
-#else
-#include <locale.h>
 #endif
+#include <locale.h>
 
 #if defined(_WIN32) || defined(WIN32) || defined(_WIN64) || defined(WIN64) || defined(WINDOWS)
 typedef _locale_t xls_locale_t;

--- a/include/libxls/locale.h
+++ b/include/libxls/locale.h
@@ -1,0 +1,15 @@
+#ifdef HAVE_XLOCALE_H
+#include <xlocale.h>
+#else
+#include <locale.h>
+#endif
+
+#if defined(_WIN32) || defined(WIN32) || defined(_WIN64) || defined(WIN64) || defined(WINDOWS)
+typedef _locale_t xls_locale_t;
+#else
+typedef locale_t xls_locale_t;
+#endif
+
+xls_locale_t xls_createlocale(void);
+void xls_freelocale(xls_locale_t locale);
+size_t xls_wcstombs_l(char *restrict s, const wchar_t *restrict pwcs, size_t n, xls_locale_t loc);

--- a/include/libxls/xlsstruct.h
+++ b/include/libxls/xlsstruct.h
@@ -500,6 +500,9 @@ typedef struct xlsWorkBook
 
 	char		*summary;		// ole file
 	char		*docSummary;	// ole file
+
+    void        *converter;
+    void        *utf16_converter;
 }
 xlsWorkBook;
 

--- a/include/libxls/xlsstruct.h
+++ b/include/libxls/xlsstruct.h
@@ -503,6 +503,7 @@ typedef struct xlsWorkBook
 
     void        *converter;
     void        *utf16_converter;
+    void        *utf8_locale;
 }
 xlsWorkBook;
 

--- a/include/libxls/xlstool.h
+++ b/include/libxls/xlstool.h
@@ -37,8 +37,7 @@
 
 void verbose(char* str);
 
-char *utf8_decode(const char *str, DWORD len, char *encoding);
-char *codepage_decode(const char *s, size_t len, WORD codepage, size_t *newlen, const char* encoding);
+char *codepage_decode(const char *s, size_t len, xlsWorkBook *pWB);
 char *unicode_decode(const char *s, size_t len, size_t *newlen, const char* encoding);
 char *get_string(const char *s, size_t len, BYTE is2, xlsWorkBook *pWB);
 DWORD xls_getColor(const WORD color,WORD def);

--- a/include/libxls/xlstool.h
+++ b/include/libxls/xlstool.h
@@ -38,8 +38,9 @@
 void verbose(char* str);
 
 char *utf8_decode(const char *str, DWORD len, char *encoding);
+char *codepage_decode(const char *s, size_t len, WORD codepage, size_t *newlen, const char* encoding);
 char *unicode_decode(const char *s, size_t len, size_t *newlen, const char* encoding);
-char *get_string(const char *s, size_t len, BYTE is2, BYTE isUnicode, char *charset);
+char *get_string(const char *s, size_t len, BYTE is2, xlsWorkBook *pWB);
 DWORD xls_getColor(const WORD color,WORD def);
 
 void xls_showBookInfo(xlsWorkBook* pWB);

--- a/include/libxls/xlstool.h
+++ b/include/libxls/xlstool.h
@@ -38,7 +38,8 @@
 void verbose(char* str);
 
 char *codepage_decode(const char *s, size_t len, xlsWorkBook *pWB);
-char *unicode_decode(const char *s, size_t len, size_t *newlen, const char* encoding);
+char *unicode_decode(const char *s, size_t len, xlsWorkBook *pWB);
+char *transcode_utf16_to_utf8(const char *s, size_t len);
 char *get_string(const char *s, size_t len, BYTE is2, xlsWorkBook *pWB);
 DWORD xls_getColor(const WORD color,WORD def);
 

--- a/src/locale.c
+++ b/src/locale.c
@@ -25,7 +25,7 @@ size_t xls_wcstombs_l(char *restrict s, const wchar_t *restrict pwcs, size_t n, 
     return wcstombs_l(s, pwcs, n, loc);
 #else
     locale_t oldlocale = uselocale(loc);
-    size_t result = wcstombs(s, pwcs, n, loc);
+    size_t result = wcstombs(s, pwcs, n);
     uselocale(oldlocale);
     return result;
 #endif

--- a/src/locale.c
+++ b/src/locale.c
@@ -1,0 +1,32 @@
+#include "config.h"
+#include <stdlib.h>
+#include "../include/libxls/locale.h"
+
+xls_locale_t xls_createlocale() {
+#if defined(_WIN32) || defined(WIN32) || defined(_WIN64) || defined(WIN64) || defined(WINDOWS)
+    return _create_locale(LC_CTYPE, ".65001");
+#else
+    return newlocale(LC_CTYPE_MASK, "UTF-8", NULL);
+#endif
+}
+
+void xls_freelocale(xls_locale_t locale) {
+#if defined(_WIN32) || defined(WIN32) || defined(_WIN64) || defined(WIN64) || defined(WINDOWS)
+    _free_locale(locale);
+#else
+    freelocale(locale);
+#endif
+}
+
+size_t xls_wcstombs_l(char *restrict s, const wchar_t *restrict pwcs, size_t n, xls_locale_t loc) {
+#if defined(_WIN32) || defined(WIN32) || defined(_WIN64) || defined(WIN64) || defined(WINDOWS)
+    return _wcstombs_l(s, pwcs, n, loc);
+#elif defined(HAVE_XLOCALE_H)
+    return wcstombs_l(s, pwcs, n, loc);
+#else
+    locale_t oldlocale = uselocale(loc);
+    size_t result = wcstombs(s, pwcs, n, loc);
+    uselocale(oldlocale);
+    return result;
+#endif
+}

--- a/src/locale.c
+++ b/src/locale.c
@@ -6,11 +6,13 @@ xls_locale_t xls_createlocale() {
 #if defined(_WIN32) || defined(WIN32) || defined(_WIN64) || defined(WIN64) || defined(WINDOWS)
     return _create_locale(LC_CTYPE, ".65001");
 #else
-    return newlocale(LC_CTYPE_MASK, "UTF-8", NULL);
+    return newlocale(LC_CTYPE_MASK, "C.UTF-8", NULL);
 #endif
 }
 
 void xls_freelocale(xls_locale_t locale) {
+    if (!locale)
+        return;
 #if defined(_WIN32) || defined(WIN32) || defined(_WIN64) || defined(WIN64) || defined(WINDOWS)
     _free_locale(locale);
 #else

--- a/src/locale.c
+++ b/src/locale.c
@@ -21,7 +21,7 @@ void xls_freelocale(xls_locale_t locale) {
 size_t xls_wcstombs_l(char *restrict s, const wchar_t *restrict pwcs, size_t n, xls_locale_t loc) {
 #if defined(_WIN32) || defined(WIN32) || defined(_WIN64) || defined(WIN64) || defined(WINDOWS)
     return _wcstombs_l(s, pwcs, n, loc);
-#elif defined(HAVE_XLOCALE_H)
+#elif defined(HAVE_WCSTOMBS_L)
     return wcstombs_l(s, pwcs, n, loc);
 #else
     locale_t oldlocale = uselocale(loc);

--- a/src/ole.c
+++ b/src/ole.c
@@ -484,7 +484,7 @@ static ssize_t ole2_read_body(OLE2 *ole) {
             total_bytes_read = -1;
             goto cleanup;
         }
-        name=unicode_decode(pss->name, pss->bsize, 0, "UTF-8");
+        name=unicode_decode(pss->name, pss->bsize, NULL, "UTF-8");
 #ifdef OLE_DEBUG	
 		fprintf(stderr, "OLE NAME: %s count=%d\n", name, (int)ole->files.count);
 #endif

--- a/src/ole.c
+++ b/src/ole.c
@@ -493,7 +493,7 @@ static ssize_t ole2_read_body(OLE2 *ole) {
             total_bytes_read = -1;
             goto cleanup;
         }
-        name=unicode_decode(pss->name, pss->bsize, NULL, "UTF-8");
+        name=transcode_utf16_to_utf8(pss->name, pss->bsize);
 #ifdef OLE_DEBUG	
 		fprintf(stderr, "OLE NAME: %s count=%d\n", name, (int)ole->files.count);
 #endif

--- a/src/xls.c
+++ b/src/xls.c
@@ -1608,8 +1608,8 @@ void xls_close_WB(xlsWorkBook* pWB)
     if (pWB->utf8_locale)
         xls_freelocale((xls_locale_t)pWB->utf8_locale);
 
-	// TODO - free other dynamically allocated objects like string table??
-	free(pWB);
+    // TODO - free other dynamically allocated objects like string table??
+    free(pWB);
 }
 
 void xls_close_WS(xlsWorkSheet* pWS)

--- a/src/xls.c
+++ b/src/xls.c
@@ -44,7 +44,9 @@
 #include <iconv.h>
 #endif
 
+#ifdef HAVE_XLOCALE_H
 #include <xlocale.h>
+#endif
 
 #include <memory.h>
 #include <math.h>

--- a/src/xls.c
+++ b/src/xls.c
@@ -219,8 +219,8 @@ static xls_error_t xls_appendSST(xlsWorkBook* pWB, BYTE* buf, DWORD size)
 		// Read characters (compressed or not)
         ln_toread = 0;
         if (ln > 0) {
-            size_t new_len = 0;
             if (flag & 0x1) {
+                size_t new_len = 0;
                 ln_toread = min((size-ofs)/2, ln);
                 ret=unicode_decode((char *)buf+ofs, ln_toread*2, &new_len, pWB->charset);
 
@@ -238,14 +238,9 @@ static xls_error_t xls_appendSST(xlsWorkBook* pWB, BYTE* buf, DWORD size)
             } else {
                 ln_toread = min((size-ofs), ln);
 
-                if (pWB->is5ver) {
-                    ret = codepage_decode((char *)buf+ofs, ln_toread, pWB->codepage, &new_len, pWB->charset);
-                    if (ret == NULL) {
-                        ret = strdup("*failed to decode BIFF5 string*");
-                        new_len = strlen(ret);
-                    }
-                } else {
-                    ret = utf8_decode((char *)buf+ofs, ln_toread, pWB->charset);
+                ret = codepage_decode((char *)buf+ofs, ln_toread, pWB);
+                if (ret == NULL) {
+                    ret = strdup("*failed to decode BIFF5 string*");
                 }
 
                 ln  -= ln_toread;

--- a/src/xls.c
+++ b/src/xls.c
@@ -44,10 +44,6 @@
 #include <iconv.h>
 #endif
 
-#ifdef HAVE_XLOCALE_H
-#include <xlocale.h>
-#endif
-
 #include <memory.h>
 #include <math.h>
 #include <sys/types.h>
@@ -55,6 +51,7 @@
 #include <wchar.h>
 
 #include "../include/libxls/endian.h"
+#include "../include/libxls/locale.h"
 #include "../include/xls.h"
 
 #ifndef min
@@ -1609,7 +1606,7 @@ void xls_close_WB(xlsWorkBook* pWB)
 #endif
 
     if (pWB->utf8_locale)
-        freelocale((locale_t)pWB->utf8_locale);
+        xls_freelocale((xls_locale_t)pWB->utf8_locale);
 
 	// TODO - free other dynamically allocated objects like string table??
 	free(pWB);

--- a/src/xls.c
+++ b/src/xls.c
@@ -44,6 +44,8 @@
 #include <iconv.h>
 #endif
 
+#include <xlocale.h>
+
 #include <memory.h>
 #include <math.h>
 #include <sys/types.h>
@@ -1603,6 +1605,9 @@ void xls_close_WB(xlsWorkBook* pWB)
     if (pWB->utf16_converter)
         iconv_close((iconv_t)pWB->utf16_converter);
 #endif
+
+    if (pWB->utf8_locale)
+        freelocale((locale_t)pWB->utf8_locale);
 
 	// TODO - free other dynamically allocated objects like string table??
 	free(pWB);

--- a/src/xlstool.c
+++ b/src/xlstool.c
@@ -306,19 +306,53 @@ static char *unicode_decode_wcstombs(const char *s, size_t len, size_t *newlen) 
 #endif
 
 #ifdef HAVE_ICONV
+struct codepage_entry_t {
+    int code;
+    const char *name;
+};
+
+static struct codepage_entry_t _codepage_entries[] = {
+    { .code = 874, .name = "WINDOWS-874" },
+    { .code = 932, .name = "SHIFT-JIS" },
+    { .code = 936, .name = "WINDOWS-936" },
+    { .code = 950, .name = "BIG-5" },
+    { .code = 951, .name = "BIG5-HKSCS" },
+    { .code = 1250, .name = "WINDOWS-1250" },
+    { .code = 1251, .name = "WINDOWS-1251" },
+    { .code = 1252, .name = "WINDOWS-1252" },
+    { .code = 1253, .name = "WINDOWS-1253" },
+    { .code = 1254, .name = "WINDOWS-1254" },
+    { .code = 1255, .name = "WINDOWS-1255" },
+    { .code = 1256, .name = "WINDOWS-1256" },
+    { .code = 1257, .name = "WINDOWS-1257" },
+    { .code = 1258, .name = "WINDOWS-1258" },
+    { .code = 10000, .name = "MACROMAN" },
+    { .code = 10004, .name = "MACARABIC" },
+    { .code = 10005, .name = "MACHEBREW" },
+    { .code = 10006, .name = "MACGREEK" },
+    { .code = 10007, .name = "MACCYRILLIC" },
+    { .code = 10010, .name = "MACROMANIA" },
+    { .code = 10017, .name = "MACUKRAINE" },
+    { .code = 10021, .name = "MACTHAI" },
+    { .code = 10029, .name = "MACCENTRALEUROPE" },
+    { .code = 10079, .name = "MACICELAND" },
+    { .code = 10081, .name = "MACTURKISH" },
+    { .code = 10082, .name = "MACCROATIAN" },
+};
+
+static int codepage_compare(const void *key, const void *value) {
+    const struct codepage_entry_t *cp1 = key;
+    const struct codepage_entry_t *cp2 = value;
+    return cp1->code - cp2->code;
+}
+
 static const char *encoding_for_codepage(WORD codepage) {
-    switch (codepage) {
-        case 874:  return "WINDOWS-874";
-        case 936:  return "WINDOWS-936";
-        case 1250: return "WINDOWS-1250";
-        case 1251: return "WINDOWS-1251";
-        case 1252: return "WINDOWS-1252";
-        case 1253: return "WINDOWS-1253";
-        case 1254: return "WINDOWS-1254";
-        case 1255: return "WINDOWS-1255";
-        case 1256: return "WINDOWS-1256";
-        case 1257: return "WINDOWS-1257";
-        case 1258: return "WINDOWS-1258";
+    struct codepage_entry_t key = { .code = codepage };
+    struct codepage_entry_t *result = bsearch(&key, _codepage_entries,
+            sizeof(_codepage_entries)/sizeof(_codepage_entries[0]),
+            sizeof(_codepage_entries[0]), &codepage_compare);
+    if (result) {
+        return result->name;
     }
     return "WINDOWS-1252";
 }

--- a/src/xlstool.c
+++ b/src/xlstool.c
@@ -305,6 +305,7 @@ static char *unicode_decode_wcstombs(const char *s, size_t len, size_t *newlen) 
 }
 #endif
 
+#ifdef HAVE_ICONV
 static const char *encoding_for_codepage(WORD codepage) {
     switch (codepage) {
         case 874:  return "WINDOWS-874";
@@ -321,6 +322,7 @@ static const char *encoding_for_codepage(WORD codepage) {
     }
     return "WINDOWS-1252";
 }
+#endif
 
 // Convert BIFF5 string to to_enc encoding
 // Returns a NUL-terminated string

--- a/src/xlstool.c
+++ b/src/xlstool.c
@@ -342,7 +342,7 @@ char* codepage_decode(const char *s, size_t len, xlsWorkBook *pWB) {
 
 // Convert unicode string to UTF-8
 char* transcode_utf16_to_utf8(const char *s, size_t len) {
-    locale_t locale = xls_createlocale();
+    xls_locale_t locale = xls_createlocale();
     char *result = unicode_decode_wcstombs(s, len, locale);
     xls_freelocale(locale);
     return result;
@@ -368,7 +368,7 @@ char* unicode_decode(const char *s, size_t len, xlsWorkBook *pWB)
     return unicode_decode_iconv(s, len, pWB->utf16_converter);
 #else
     if (!pWB->utf8_locale) {
-        locale_t locale = newlocale(LC_CTYPE_MASK, utf8_locale_name, NULL);
+        xls_locale_t locale = xls_createlocale();
         if (locale == NULL) {
             printf("creation of '%s' locale failed\n", utf8_locale_name);
             return NULL;

--- a/src/xlstool.c
+++ b/src/xlstool.c
@@ -370,7 +370,7 @@ char* unicode_decode(const char *s, size_t len, xlsWorkBook *pWB)
     if (!pWB->utf8_locale) {
         xls_locale_t locale = xls_createlocale();
         if (locale == NULL) {
-            printf("creation of '%s' locale failed\n", utf8_locale_name);
+            printf("creation of UTF-8 locale failed\n");
             return NULL;
         }
         pWB->utf8_locale = (void *)locale;

--- a/src/xlstool.c
+++ b/src/xlstool.c
@@ -44,6 +44,10 @@
 #include <iconv.h>
 #endif
 
+#ifdef HAVE_XLOCALE_H
+#include <xlocale.h>
+#endif
+
 #include <locale.h>
 #include <limits.h>
 
@@ -51,7 +55,6 @@
 #include <errno.h>
 #include <memory.h>
 #include <string.h>
-#include <xlocale.h>
 
 //#include "xls.h"
 #include "../include/libxls/xlstypes.h"


### PR DESCRIPTION
Pre-Unicode (BIFF5) files include a `CODEPAGE` record. Attempt to use the information in this record to transcode strings via iconv. This might introduce a little bit of slowness - in the future it would be better to create a single `iconv_t` to pass around, but this will probably break the ABI and require a minor version bump.

For starters I've hard-coded the major Windows code pages - more can be added later, but it would help to find a comprehensive list somewhere. One open question is whether ancient XLS files created on MacOS use Mac character sets (Mac Roman, Mac Arabic, etc).

Leaving open for now so that others can test this branch before merging it into dev.