### PR TITLE
fix some memory leaks

### DIFF
--- a/src/xls2csv.c
+++ b/src/xls2csv.c
@@ -130,6 +130,7 @@ printf("FILE: %s\n", argv[1]);
 		if (i == pWB->sheets.count) {
 			fprintf(stderr, "Sheet \"%s\" not found", sheetName);
 			fprintf(stderr, "\n");
+			xls_close(pWB);
 			return EXIT_FAILURE;
 		}
 	}

--- a/src/xls2csv.c
+++ b/src/xls2csv.c
@@ -89,16 +89,16 @@ int main(int argc, char *argv[]) {
             justList = 1;
             break;
         case 'e':
-            encoding = strdup(optarg);
+            encoding = optarg;
             break;
         case 't':
-            sheetName = strdup(optarg);
+            sheetName = optarg;
             break;
         case 'q':
             stringSeparator = optarg[0];
             break;
         case 'f':
-            fieldSeparator = strdup(optarg);
+            fieldSeparator = optarg;
             break;
         case 'v':
             xls(1);


### PR DESCRIPTION
I fix some memory leaks in xls2csv.
`optarg` is a string pointer, it can directly use without `strdup`.
Free xls file when use `-t` but sheet not found.