### PR TITLE
Fix NULL pointer dereference on test.c

### DIFF
--- a/test/test.c
+++ b/test/test.c
@@ -66,6 +66,8 @@ int main(int argc, char *argv[])
         printf("Sheet N%i (%s) pos %i\n",i,pWB->sheets.sheet[i].name,pWB->sheets.sheet[i].filepos);
 
     pWS=xls_getWorkSheet(pWB,0);
+    if(!pWS) return 1;
+    
     if ((code = xls_parseWorkSheet(pWS)) != LIBXLS_OK) {
         fprintf(stderr, "Error parsing worksheet: %s\n", xls_getError(code));
         return 1;


### PR DESCRIPTION
Fix libxls library misuse leading to NULL pointer dereference not taking care about `pWB->sheets.count` having to be greater than 0.