### PR TITLE
Fix possible library misuse  (NULL ptr deref)

### DIFF
--- a/src/xls.c
+++ b/src/xls.c
@@ -830,6 +830,8 @@ int xls_isRecordTooSmall(xlsWorkBook *pWB, BOF *bof1) {
 
 xls_error_t xls_parseWorkBook(xlsWorkBook* pWB)
 {
+    if(!pWB) return LIBXLS_ERROR_PARSE;
+	
     BOF bof1 = { .id = 0, .size = 0 };
     BOF bof2 = { .id = 0, .size = 0 };
     BYTE* buf = NULL;
@@ -1072,6 +1074,9 @@ cleanup:
 
 static xls_error_t xls_preparseWorkSheet(xlsWorkSheet* pWS)
 {
+
+    if(!pWS) return LIBXLS_ERROR_PARSE;
+
     BOF tmp;
     BYTE* buf = NULL;
     xls_error_t retval = LIBXLS_OK;
@@ -1221,6 +1226,9 @@ static xls_error_t xls_formatColumn(xlsWorkSheet* pWS)
 
 xls_error_t xls_parseWorkSheet(xlsWorkSheet* pWS)
 {
+
+    if(!pWS) return LIBXLS_ERROR_PARSE;
+
     BOF tmp;
     BYTE* buf = NULL;
 	long offset = pWS->filepos;


### PR DESCRIPTION
Fix a possible library misuse when using as input for a function a NULL pointer returned by a previous one, leading to a NULL pointer dereference