### PR TITLE
signature mismatch in src and header

### DIFF
--- a/src/xlstool.c
+++ b/src/xlstool.c
@@ -614,10 +614,10 @@ typedef struct st_format
 	st_format;
 #endif
 
-void xls_showFormat(struct st_format_data* frmt)
+void xls_showFormat(struct st_format_data* format)
 {
-	printf("    index : %u\n", frmt->index);
-    printf("     value: %s\n", frmt->value);
+	printf("    index : %u\n", format->index);
+    printf("     value: %s\n", format->value);
 }
 
 void xls_showXF(XF8* xf)


### PR DESCRIPTION
Conflicts with header declaration here:

https://github.com/libxls/libxls/blob/448240067919707eb95fb009f76f3fdb439b1427/include/libxls/xlstool.h#L52

Updating the variable name in src since `format` is more readable that `frmt` and the function body is very short anyway.