### PR TITLE
signature mismatch in src and header (xls)

### DIFF
--- a/src/xls.c
+++ b/src/xls.c
@@ -1498,11 +1498,11 @@ xlsWorkBook* xls_open_file(const char *file, const char* charset, xls_error_t *o
     return xls_open_ole(ole, charset, outError);
 }
 
-xlsWorkBook *xls_open_buffer(const unsigned char *buffer, size_t len,
+xlsWorkBook *xls_open_buffer(const unsigned char *data, size_t data_len,
         const char *charset, xls_error_t *outError) {
     OLE2* ole = NULL;
 
-    if (!(ole=ole2_open_buffer(buffer, len)))
+    if (!(ole=ole2_open_buffer(data, data_len)))
     {
         if (outError) *outError = LIBXLS_ERROR_OPEN;
         return NULL;


### PR DESCRIPTION
Conflicting header declaration:

https://github.com/libxls/libxls/blob/448240067919707eb95fb009f76f3fdb439b1427/include/xls.h#L67

This one, I'm less sure which is the right signature. Happy to edit the header declaration instead....