### PR TITLE
Fix header include in C++ mode

### DIFF
--- a/include/libxls/xlstypes.h
+++ b/include/libxls/xlstypes.h
@@ -36,11 +36,7 @@
 #ifndef XLS_TYPES_INC
 #define XLS_TYPES_INC
 
-#ifdef __cplusplus
-#include <cstdint>
-#else
 #include <stdint.h>
-#endif
 #include <sys/types.h>
 
 typedef unsigned char		BYTE;


### PR DESCRIPTION
This file is included in the toplevel `xls.h` within an `extern "C"`, which means including C++ headers in it is completely broken. With GCC 13, this causes strange errors due to "missing" symbols. https://koschei.fedoraproject.org/build/14612087

This reverts a small bit of #49.