### PR TITLE
Play nicely with -Wstrict-prototypes

### DIFF
--- a/src/endian.c
+++ b/src/endian.c
@@ -35,7 +35,7 @@
 #include "../include/libxls/endian.h"
 #include "../include/libxls/ole.h"
 
-int xls_is_bigendian()
+int xls_is_bigendian(void)
 {
 #if defined (__BIG_ENDIAN__)
     return 1;

--- a/src/locale.c
+++ b/src/locale.c
@@ -32,7 +32,7 @@
 #include <stdlib.h>
 #include "../include/libxls/locale.h"
 
-xls_locale_t xls_createlocale() {
+xls_locale_t xls_createlocale(void) {
 #if defined(_WIN32) || defined(WIN32) || defined(_WIN64) || defined(WIN64) || defined(WINDOWS)
     return _create_locale(LC_CTYPE, ".65001");
 #else


### PR DESCRIPTION
This is a patch I have in readxl, because CRAN warns us about this. It seems like it might be something appropriate to do here.