### PR TITLE
Fix buffer overflows when parsing style records

### DIFF
--- a/src/xls.c
+++ b/src/xls.c
@@ -800,7 +800,7 @@ static xls_error_t xls_mergedCells(xlsWorkSheet* pWS,BOF* bof,BYTE* buf)
     return LIBXLS_OK;
 }
 
-int xls_isRecordTooSmall(xlsWorkBook *pWB, BOF *bof1) {
+int xls_isRecordTooSmall(xlsWorkBook *pWB, BOF *bof1, const BYTE* buf) {
     switch (bof1->id) {
         case XLS_RECORD_BOF:	// BIFF5-8
             return (bof1->size < 2 * sizeof(WORD));
@@ -822,6 +822,24 @@ int xls_isRecordTooSmall(xlsWorkBook *pWB, BOF *bof1) {
             return (bof1->size < offsetof(FONT, name));
         case XLS_RECORD_FORMAT:
             return (bof1->size < offsetof(FORMAT, value));
+        case XLS_RECORD_STYLE:
+            {
+                struct {
+                    unsigned short idx;
+                    unsigned char ident;
+                    unsigned char lvl;
+                } *styl;
+                styl = (void *)buf;
+                if(bof1->size < 2) {
+                    return 1;
+                }
+                if(styl->idx & 0x8000) {
+                    return bof1->size < 4;
+                } else {
+                    if(bof1->size < 3) return 1;
+                    return bof1->size < 3 + styl->ident;
+                }
+            }
 		case XLS_RECORD_1904:
             return (bof1->size < sizeof(BYTE));
         default:
@@ -869,7 +887,7 @@ xls_error_t xls_parseWorkBook(xlsWorkBook* pWB)
             }
         }
 
-        if (xls_isRecordTooSmall(pWB, &bof1)) {
+        if (xls_isRecordTooSmall(pWB, &bof1, buf)) {
             retval = LIBXLS_ERROR_PARSE;
             goto cleanup;
         }


### PR DESCRIPTION
Closes #124, #126.

According to https://download.microsoft.com/download/5/0/1/501ED102-E53F-4CE0-AA6B-B0F93629DDC6/Office/Excel97-2007BinaryFileFormat(xls)Specification.pdf a "STYLE: Style Information (293h)" record might be 4 or 3+ bytes long, depending on the first word.

We need to check that we've read enough bytes for the whole record, so
- first we check that we have a word at least,
- then we check the subtype of the record.
- If it is a built-in style, then it has 4 bytes, so we check that.
- Otherwise the length of the name is in byte 3, so the whole record is 3 + buf[3] bytes long. So we need at least three bytes before we check the length in byte 3. Then we check if we have 3 + buf[3] bytes.

This bug also caused the buffer overflows in xlstools.c, the stack traces in #124 clearly show this. The functions in xlstools.c were called with the wrong arguments, i.e. the argument denoting the buffer length was wrong and the real buffer length was shorter.