### PR TITLE
Fix style record size check on big-endian systems

### DIFF
--- a/src/xls.c
+++ b/src/xls.c
@@ -829,11 +829,11 @@ int xls_isRecordTooSmall(xlsWorkBook *pWB, BOF *bof1, const BYTE* buf) {
                     unsigned char ident;
                     unsigned char lvl;
                 } *styl;
-                styl = (void *)buf;
                 if(bof1->size < 2) {
                     return 1;
                 }
-                if(styl->idx & 0x8000) {
+                styl = (void *)buf;
+                if(xlsShortVal(styl->idx) & 0x8000) {
                     return bof1->size < 4;
                 } else {
                     if(bof1->size < 3) return 1;


### PR DESCRIPTION
The fix made in #129 added a cast of a byte buffer to a pointer to a short. Since the file format is little endian, the check for the _value_ of `styl->idx` works on little endian machines, but fails on big endian machines due to the mismatch there.

This causes one of the tests to fail.