### PR TITLE
Don't do `#include <cstdio>` inside `extern "C" {}`

### DIFF
--- a/include/libxls/ole.h
+++ b/include/libxls/ole.h
@@ -41,11 +41,7 @@
 typedef SSIZE_T ssize_t;
 #endif
 
-#ifdef __cplusplus
-#include <cstdio>			// FILE *
-#else
 #include <stdio.h>			// FILE *
-#endif
 
 #include "../libxls/xlstypes.h"
 


### PR DESCRIPTION
Basically a follow-up to https://github.com/libxls/libxls/commit/78615b40975e770176d4f177aae266c13ec24fa1

Also removes `#include <cstdio>` from the `extern "C" {}` block.

Otherwise fails to build on aarch64-linux-gnu-g++-14 with errors like
```
/usr/aarch64-linux-gnu/include/c++/14/bits/stringfwd.h:77:33: note:   ‘std::string’
   77 |   typedef basic_string<char>    string;
      |                                 ^~~~~~
In file included from /usr/aarch64-linux-gnu/include/c++/14/bits/locale_classes.h:40,
                 from /usr/aarch64-linux-gnu/include/c++/14/bits/ios_base.h:41,
                 from /usr/aarch64-linux-gnu/include/c++/14/ios:44:
/usr/aarch64-linux-gnu/include/c++/14/string:76:11: note:   ‘std::pmr::string’
   76 |     using string    = basic_string<char>;
      |           ^~~~~~
/home/martin/.conan2/p/b/libxld488320822cd6/b/src/cplusplus/main.cpp:56:22: error: ‘s’ was not declared in this scope
   56 |         WorkBook foo(s);
```