### PR TITLE
Fix CWE-476: Prevent NULL pointer dereference in ole2_sopen and ole2_read_header

### DIFF
--- a/src/ole.c
+++ b/src/ole.c
@@ -243,6 +243,9 @@ OLE2Stream* ole2_sopen(OLE2* ole,DWORD start, size_t size)
 #endif
 
     olest = calloc(1, sizeof(OLE2Stream));
+    if (olest == NULL) {
+        return NULL;
+    }
     olest->ole=ole;
     olest->size=size;
     olest->fatpos=start;
@@ -403,6 +406,10 @@ static size_t ole2_fread(OLE2 *ole2, void *buffer, size_t buffer_len, size_t siz
 static ssize_t ole2_read_header(OLE2 *ole) {
     ssize_t bytes_read = 0, total_bytes_read = 0;
     OLE2Header *oleh = malloc(sizeof(OLE2Header));
+    if (ole == NULL || oleh == NULL) {
+        free(oleh);
+        return -1;
+    }
     if (ole2_fread(ole, oleh, sizeof(OLE2Header), sizeof(OLE2Header)) != 1) {
         total_bytes_read = -1;
         goto cleanup;


### PR DESCRIPTION
### Describe the bug
Hi
This PR fixes two instances of [CWE-476: NULL pointer dereference] in `src/ole.c`:

- In `ole2_sopen()`, the result of `calloc()` is used without checking for `NULL`.
- In `ole2_read_header()`, the result of `malloc()` is passed to `ole2_fread()` without validation.

If either allocation fails, the program may dereference a `NULL` pointer, leading to a segmentation fault or undefined behavior.

---

### Expected behavior
All memory allocation calls (`calloc()`, `malloc()`) should be checked for `NULL` before being used.

---

### Actual behavior
In both functions, the allocation result is used directly without validation, which can result in a `NULL` pointer dereference under low-memory conditions.

---

### How to Reproduce
This issue may occur in low-memory environments or under constrained conditions where memory allocation fails:

- In `ole2_sopen()`, if `calloc()` returns `NULL`, the code dereferences it immediately via `olest->ole = ole;`.
- In `ole2_read_header()`, if `malloc()` returns `NULL`, the resulting pointer is passed to `ole2_fread()`.

While this may be difficult to reproduce in typical usage, the code path clearly exposes a potential `NULL` dereference.  
This patch adds proper `NULL` checks to prevent this unsafe behavior.

---

### Patch details

- In `ole2_sopen()`, added a NULL check immediately after `calloc()`:

  ```c
  olest = calloc(1, sizeof(OLE2Stream));
  if (olest == NULL) {
      return NULL;
  }

- In `ole2_read_header()`, added a NULL check after `malloc()` and a fallback return:

  ```c
  OLE2Header *oleh = malloc(sizeof(OLE2Header));
  if (ole == NULL || oleh == NULL) {
      free(oleh);
      return -1;
  }


These checks ensure safe handling of memory allocation failures and prevent crashes due to NULL pointer dereference.

Thank you for your consideration. I look forward to your feedback

