### PR TITLE
fix: add include guards to headers (closes #137)

### DIFF
--- a/include/libxls/brdb.h
+++ b/include/libxls/brdb.h
@@ -33,6 +33,9 @@
  *
  */
 
+#ifndef BRDB_INCLUDE
+#define BRDB_INCLUDE
+
 struct str_brdb
 {
     WORD opcode;
@@ -60,3 +63,5 @@ static int get_brbdnum(int id)
     while (brdb[i].opcode!=0xFFF);
     return 0;
 }
+
+#endif // BRDB_INCLUDE

--- a/include/libxls/endian.h
+++ b/include/libxls/endian.h
@@ -29,6 +29,9 @@
  *
  */
 
+#ifndef ENDIAN_INCLUDE
+#define ENDIAN_INCLUDE
+
 #include "../libxls/xlsstruct.h"
 
 int xls_is_bigendian(void);
@@ -59,3 +62,5 @@ void xlsConvertPss(PSS* pss);
 
 #define W_ENDIAN(a) a=xlsShortVal(a)
 #define D_ENDIAN(a) a=xlsIntVal(a)
+
+#endif // ENDIAN_INCLUDE

--- a/include/libxls/locale.h
+++ b/include/libxls/locale.h
@@ -28,6 +28,9 @@
  * ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.
  *
  */
+#ifndef LOCALE_INCLUDE
+#define LOCALE_INCLUDE
+
 #ifdef HAVE_XLOCALE_H
 #include <xlocale.h>
 #endif
@@ -42,3 +45,5 @@ typedef locale_t xls_locale_t;
 xls_locale_t xls_createlocale(void);
 void xls_freelocale(xls_locale_t locale);
 size_t xls_wcstombs_l(char *restrict s, const wchar_t *restrict pwcs, size_t n, xls_locale_t loc);
+
+#endif // LOCALE_INCLUDE

--- a/include/libxls/ole.h
+++ b/include/libxls/ole.h
@@ -188,4 +188,4 @@ OLE2* ole2_open_file(const char *file);
 OLE2* ole2_open_buffer(const void *buffer, size_t len);
 void ole2_close(OLE2* ole2);
 
-#endif
+#endif // OLE_INCLUDE

--- a/include/libxls/xlsstruct.h
+++ b/include/libxls/xlsstruct.h
@@ -33,8 +33,8 @@
  *
  */
 
-#ifndef XLS_STRUCT_INC
-#define XLS_STRUCT_INC
+#ifndef XLS_STRUCT_INCLUDE
+#define XLS_STRUCT_INCLUDE
 
 #include "../libxls/ole.h"
 
@@ -543,4 +543,4 @@ xlsSummaryInfo;
 
 typedef void (*xls_formula_handler)(WORD bof, WORD len, BYTE *formula);
 
-#endif
+#endif // XLS_STRUCT_INCLUDE

--- a/include/libxls/xlstool.h
+++ b/include/libxls/xlstool.h
@@ -33,6 +33,9 @@
  *
  */
 
+#ifndef XLSTOOL_INCLUDE
+#define XLSTOOL_INCLUDE
+
 #include "../libxls/xlsstruct.h"
 
 void verbose(char* str);
@@ -53,3 +56,5 @@ void xls_showFormat(struct st_format_data* format);
 char* xls_getfcell(xlsWorkBook* pWB, struct st_cell_data* cell, BYTE *label);
 char* xls_getCSS(xlsWorkBook* pWB);
 void xls_showBOF(BOF* bof);
+
+#endif // XLSTOOL_INCLUDE

--- a/include/libxls/xlstypes.h
+++ b/include/libxls/xlstypes.h
@@ -33,8 +33,8 @@
  *
  */
 
-#ifndef XLS_TYPES_INC
-#define XLS_TYPES_INC
+#ifndef XLS_TYPES_INCLUDE
+#define XLS_TYPES_INCLUDE
 
 #include <stdint.h>
 #include <sys/types.h>
@@ -49,4 +49,4 @@ typedef unsigned __int64	unsigned64_t;
 typedef uint64_t			unsigned64_t;
 #endif
 
-#endif
+#endif // XLS_TYPES_INCLUDE

--- a/include/xls.h
+++ b/include/xls.h
@@ -89,5 +89,5 @@ xlsCell	*xls_cell(xlsWorkSheet* pWS, WORD cellRow, WORD cellCol);
 } // namespace
 #endif
 
-#endif
+#endif // XLS_INCLUDE
 


### PR DESCRIPTION
Hello!

I noticed issue #137 mentioned the need for include guards in header files, so I’ve added them to prevent recursive inclusion. 

This is my first contribution here, so please let me know if anything needs adjustment — I’m happy to improve it!

Best regards!