### PR TITLE
Fix use of uninitialized memory in xls_parseWorkBook (Fixes #154)

### DIFF
--- a/src/ole.c
+++ b/src/ole.c
@@ -172,6 +172,9 @@ ssize_t ole2_read(void* buf, size_t size, size_t count, OLE2Stream* olest)
     size_t totalReadCount;
 
 	totalReadCount=size*count;
+    if (buf && totalReadCount > 0) {
+        memset(buf, 0, totalReadCount);
+    }
 
 	// olest->size inited to -1
 	// printf("===== ole2_read(%ld bytes)\n", totalReadCount);

--- a/src/xls.c
+++ b/src/xls.c
@@ -875,11 +875,14 @@ xls_error_t xls_parseWorkBook(xlsWorkBook* pWB)
  		if(xls_debug) xls_showBOF(&bof1);
 
         if (bof1.size) {
-            if ((buf = realloc(buf, bof1.size)) == NULL) {
+            BYTE *new_buf = realloc(buf, bof1.size);
+            if (new_buf == NULL) {
                 if (xls_debug) fprintf(stderr, "Error: failed to allocate buffer of size %d\n", (int)bof1.size);
                 retval = LIBXLS_ERROR_MALLOC;
                 goto cleanup;
             }
+            buf = new_buf;
+            memset(buf, 0, bof1.size);
             if (ole2_read(buf, 1, bof1.size, pWB->olestr) != bof1.size) {
                 if (xls_debug) fprintf(stderr, "Error: failed to read OLE block\n");
                 retval = LIBXLS_ERROR_READ;
@@ -1120,11 +1123,14 @@ static xls_error_t xls_preparseWorkSheet(xlsWorkSheet* pWS)
         }
         xlsConvertBof(&tmp);
         if (tmp.size) {
-            if ((buf = realloc(buf, tmp.size)) == NULL) {
+            BYTE *new_buf = realloc(buf, tmp.size);
+            if (new_buf == NULL) {
                 if (xls_debug) fprintf(stderr, "Error: failed to allocate buffer of size %d\n", (int)tmp.size);
                 retval = LIBXLS_ERROR_MALLOC;
                 goto cleanup;
             }
+            buf = new_buf;
+            memset(buf, 0, tmp.size);
             if((read = ole2_read(buf, 1, tmp.size, pWS->workbook->olestr)) != tmp.size) {
                 if (xls_debug) fprintf(stderr, "Error: failed to read OLE block\n");
                 retval = LIBXLS_ERROR_READ;
@@ -1293,11 +1299,14 @@ xls_error_t xls_parseWorkSheet(xlsWorkSheet* pWS)
         }
         xlsConvertBof((BOF *)&tmp);
         if (tmp.size) {
-            if ((buf = realloc(buf, tmp.size)) == NULL) {
+            BYTE *new_buf = realloc(buf, tmp.size);
+            if (new_buf == NULL) {
                 if (xls_debug) fprintf(stderr, "Error: failed to allocate buffer of size %d\n", (int)tmp.size);
                 retval = LIBXLS_ERROR_MALLOC;
                 goto cleanup;
             }
+            buf = new_buf;
+            memset(buf, 0, tmp.size);
             if((read = ole2_read(buf, 1, tmp.size, pWS->workbook->olestr)) != tmp.size) {
                 if (xls_debug) fprintf(stderr, "Error: failed to read OLE block\n");
                 retval = LIBXLS_ERROR_READ;


### PR DESCRIPTION
- Zero-fill destination buffer at entry of ole2_read to prevent reading uninitialized memory on truncated streams or EOF.
- Zero-initialize reallocated record buffers in xls_parseWorkBook, xls_preparseWorkSheet, and xls_parseWorkSheet before calling ole2_read.

    The Valgrind stack trace at `ole2_sopen` (`ole2_validate_sector_chain`) was actually the original bug from `libxls 1.6.3` (**Issue #156**), which was fixed
  by the previous merged PR **#157** (which converted `ole_malloc` to `calloc` and initialized `SecID`/`SSecID` with `0xFF`).

    Testing `testcase` with Valgrind Memcheck (`valgrind --tool=memcheck --track-origins=yes`) on this branch confirms **0 errors**:

    ```text
    ==4533== HEAP SUMMARY:
    ==4533==     in use at exit: 0 bytes in 0 blocks
    ==4533==   total heap usage: 73 allocs, 73 frees, 4,224,140 bytes allocated
    ==4533== All heap blocks were freed -- no leaks are possible
    ==4533== ERROR SUMMARY: 0 errors from 0 contexts (suppressed: 0 from 0)

  This PR adds defensive zero-initialization to ole2_read() and realloc record buffers in xls.c to prevent uninitialized memory reads when BIFF stream records
  encounter short reads or early EOFs during workbook/worksheet parsing.