### PR TITLE
Fix allocation-failure handling in OLE, workbook and string paths

### DIFF
--- a/src/ole.c
+++ b/src/ole.c
@@ -256,6 +256,8 @@ OLE2Stream* ole2_sopen(OLE2* ole,DWORD start, size_t size)
 #endif
 
     olest = calloc(1, sizeof(OLE2Stream));
+    if (olest == NULL)
+        return NULL;
     olest->ole=ole;
     olest->size=size;
     olest->fatpos=start;
@@ -416,6 +418,8 @@ static size_t ole2_fread(OLE2 *ole2, void *buffer, size_t buffer_len, size_t siz
 static ssize_t ole2_read_header(OLE2 *ole) {
     ssize_t bytes_read = 0, total_bytes_read = 0;
     OLE2Header *oleh = calloc(1, sizeof(OLE2Header));
+    if (oleh == NULL)
+        return -1;
     if (ole2_fread(ole, oleh, sizeof(OLE2Header), sizeof(OLE2Header)) != 1) {
         total_bytes_read = -1;
         goto cleanup;
@@ -494,6 +498,10 @@ static ssize_t ole2_read_body(OLE2 *ole) {
         goto cleanup;
     }
     pss = calloc(1, sizeof(PSS));
+    if (pss == NULL) {
+        total_bytes_read = -1;
+        goto cleanup;
+    }
     do {
         if ((bytes_read = ole2_read(pss,1,sizeof(PSS),olest)) == -1) {
             total_bytes_read = -1;
@@ -517,7 +525,14 @@ static ssize_t ole2_read_body(OLE2 *ole) {
                     pss->type == PS_USER_ROOT ? "root" : "user",
                     (int)ole->files.count, (int)pss->size);
 #endif		
-            ole->files.file = realloc(ole->files.file,(ole->files.count+1)*sizeof(struct st_olefiles_data));
+            struct st_olefiles_data *new_files = realloc(ole->files.file,
+                    (ole->files.count+1)*sizeof(struct st_olefiles_data));
+            if (new_files == NULL) {
+                free(name);
+                total_bytes_read = -1;
+                goto cleanup;
+            }
+            ole->files.file = new_files;
             ole->files.file[ole->files.count].name=name;
             ole->files.file[ole->files.count].start=pss->sstart;
             ole->files.file[ole->files.count].size=pss->size;
@@ -620,6 +635,8 @@ OLE2 *ole2_read_header_and_body(OLE2 *ole) {
 // Open in-memory buffer
 OLE2 *ole2_open_buffer(const void *buffer, size_t len) {
     OLE2 *ole = calloc(1, sizeof(OLE2));
+    if (ole == NULL)
+        return NULL;
 
     ole->buffer = buffer;
     ole->buffer_len = len;
@@ -639,6 +656,8 @@ OLE2* ole2_open_file(const char *file)
 
 	if(xls_debug) printf("ole2_open: %s\n", file);
     ole = calloc(1, sizeof(OLE2));
+    if (ole == NULL)
+        return NULL;
 
     if (!(ole->file=fopen(file, "rb"))) {
         if(xls_debug) fprintf(stderr, "File not found\n");
@@ -727,6 +746,8 @@ static ssize_t read_MSAT_body(OLE2 *ole2, DWORD sectorOffset, DWORD sectorCount)
     DWORD sectorNum = sectorOffset;
 
     DWORD *sector = ole_malloc(ole2->lsector);
+    if (sector == NULL)
+        return -1;
     //printf("sid=%u (0x%x) sector=%u\n", sid, sid, ole2->lsector);
     while (sid != ENDOFCHAIN && sid != FREESECT) // FREESECT only here due to an actual file that requires it (old Apple Numbers bug)
     {

--- a/src/xls.c
+++ b/src/xls.c
@@ -139,9 +139,12 @@ static xls_error_t xls_addSST(xlsWorkBook* pWB,SST* sst,DWORD size)
     if (pWB->sst.string)
         return LIBXLS_ERROR_PARSE;
 
-    if ((pWB->sst.string = calloc(pWB->sst.count = sst->num,
-                    sizeof(struct str_sst_string))) == NULL)
+    if ((pWB->sst.string = calloc(sst->num,
+                    sizeof(struct str_sst_string))) == NULL) {
+        pWB->sst.count = 0;
         return LIBXLS_ERROR_MALLOC;
+    }
+    pWB->sst.count = sst->num;
 
     return xls_appendSST(pWB, sst->strings, size - offsetof(SST, strings));
 }
@@ -389,11 +392,12 @@ static xls_error_t xls_addSheet(xlsWorkBook* pWB, BOUNDSHEET *bs, DWORD size)
 		printf("   name: %s\n", name);
 	}
 
-    pWB->sheets.sheet = realloc(pWB->sheets.sheet,(pWB->sheets.count+1)*sizeof (struct st_sheet_data));
-    if (pWB->sheets.sheet == NULL) {
+    struct st_sheet_data *new_sheets = realloc(pWB->sheets.sheet,(pWB->sheets.count+1)*sizeof (struct st_sheet_data));
+    if (new_sheets == NULL) {
         free(name);
         return LIBXLS_ERROR_MALLOC;
     }
+    pWB->sheets.sheet = new_sheets;
 
     pWB->sheets.sheet[pWB->sheets.count].name=name;
     pWB->sheets.sheet[pWB->sheets.count].filepos=filepos;
@@ -444,8 +448,10 @@ static xls_error_t xls_makeTable(xlsWorkSheet* pWS)
         tmp->lcell=pWS->rows.lastcol;
 
 		tmp->cells.count = pWS->rows.lastcol+1;
-        if ((tmp->cells.cell = calloc(tmp->cells.count, sizeof(struct st_cell_data))) == NULL)
+        if ((tmp->cells.cell = calloc(tmp->cells.count, sizeof(struct st_cell_data))) == NULL) {
+            tmp->cells.count = 0;
             return LIBXLS_ERROR_MALLOC;
+        }
 
         for (i=0;i<=pWS->rows.lastcol;i++)
         {
@@ -642,9 +648,10 @@ static char *xls_addFont(xlsWorkBook* pWB, FONT* font, DWORD size)
 
     verbose("xls_addFont");
 
-    pWB->fonts.font = realloc(pWB->fonts.font,(pWB->fonts.count+1)*sizeof(struct st_font_data));
-    if (pWB->fonts.font == NULL)
+    struct st_font_data *new_fonts = realloc(pWB->fonts.font,(pWB->fonts.count+1)*sizeof(struct st_font_data));
+    if (new_fonts == NULL)
         return NULL;
+    pWB->fonts.font = new_fonts;
 
     tmp=&pWB->fonts.font[pWB->fonts.count];
 
@@ -670,9 +677,10 @@ static xls_error_t xls_addFormat(xlsWorkBook* pWB, FORMAT* format, DWORD size)
     struct st_format_data* tmp;
 
     verbose("xls_addFormat");
-    pWB->formats.format = realloc(pWB->formats.format, (pWB->formats.count+1)*sizeof(struct st_format_data));
-    if (pWB->formats.format == NULL)
+    struct st_format_data *new_formats = realloc(pWB->formats.format, (pWB->formats.count+1)*sizeof(struct st_format_data));
+    if (new_formats == NULL)
         return LIBXLS_ERROR_MALLOC;
+    pWB->formats.format = new_formats;
 
     tmp = &pWB->formats.format[pWB->formats.count];
     tmp->index = format->index;
@@ -688,9 +696,10 @@ static xls_error_t xls_addXF8(xlsWorkBook* pWB,XF8* xf)
     struct st_xf_data* tmp;
 
     verbose("xls_addXF");
-    pWB->xfs.xf= realloc(pWB->xfs.xf, (pWB->xfs.count+1)*sizeof(struct st_xf_data));
-    if (pWB->xfs.xf == NULL)
+    struct st_xf_data *new_xfs8 = realloc(pWB->xfs.xf, (pWB->xfs.count+1)*sizeof(struct st_xf_data));
+    if (new_xfs8 == NULL)
         return LIBXLS_ERROR_MALLOC;
+    pWB->xfs.xf = new_xfs8;
 
     tmp=&pWB->xfs.xf[pWB->xfs.count];
 
@@ -716,9 +725,10 @@ static xls_error_t xls_addXF5(xlsWorkBook* pWB,XF5* xf)
     struct st_xf_data* tmp;
 
     verbose("xls_addXF");
-    pWB->xfs.xf = realloc(pWB->xfs.xf, (pWB->xfs.count+1)*sizeof(struct st_xf_data));
-    if (pWB->xfs.xf == NULL)
+    struct st_xf_data *new_xfs5 = realloc(pWB->xfs.xf, (pWB->xfs.count+1)*sizeof(struct st_xf_data));
+    if (new_xfs5 == NULL)
         return LIBXLS_ERROR_MALLOC;
+    pWB->xfs.xf = new_xfs5;
 
     tmp=&pWB->xfs.xf[pWB->xfs.count];
 
@@ -745,9 +755,10 @@ static xls_error_t xls_addColinfo(xlsWorkSheet* pWS,COLINFO* colinfo)
     struct st_colinfo_data* tmp;
 
     verbose("xls_addColinfo");
-    pWS->colinfo.col =  realloc(pWS->colinfo.col,(pWS->colinfo.count+1)*sizeof(struct st_colinfo_data));
-    if (pWS->colinfo.col == NULL)
+    struct st_colinfo_data *new_cols = realloc(pWS->colinfo.col,(pWS->colinfo.count+1)*sizeof(struct st_colinfo_data));
+    if (new_cols == NULL)
         return LIBXLS_ERROR_MALLOC;
+    pWS->colinfo.col = new_cols;
 
     tmp=&pWS->colinfo.col[pWS->colinfo.count];
     tmp->first=colinfo->first;
@@ -1436,6 +1447,8 @@ xlsWorkSheet * xls_getWorkSheet(xlsWorkBook* pWB,int num)
     verbose ("xls_getWorkSheet");
     if (num >= 0 && num < (int)pWB->sheets.count) {
         pWS = calloc(1, sizeof(xlsWorkSheet));
+        if (pWS == NULL)
+            return NULL;
         pWS->filepos=pWB->sheets.sheet[num].filepos;
         pWS->workbook=pWB;
         pWS->rows.lastcol=0;
@@ -1450,11 +1463,21 @@ static xlsWorkBook *xls_open_ole(OLE2 *ole, const char *charset, xls_error_t *ou
     xls_error_t retval = LIBXLS_OK;
 
     pWB = calloc(1, sizeof(xlsWorkBook));
+    if (pWB == NULL) {
+        ole2_close(ole);
+        if (outError)
+            *outError = LIBXLS_ERROR_MALLOC;
+        return NULL;
+    }
     verbose ("xls_open_ole");
 
     if ((pWB->olestr=ole2_fopen(ole, "\005SummaryInformation")))
     {
         pWB->summary = calloc(1,4096);
+        if (pWB->summary == NULL) {
+            retval = LIBXLS_ERROR_MALLOC;
+            goto cleanup;
+        }
 		if (ole2_read(pWB->summary, 4096, 1, pWB->olestr) == -1) {
             if (xls_debug) fprintf(stderr, "SummaryInformation not found\n");
             retval = LIBXLS_ERROR_READ;
@@ -1466,6 +1489,10 @@ static xlsWorkBook *xls_open_ole(OLE2 *ole, const char *charset, xls_error_t *ou
     if ((pWB->olestr=ole2_fopen(ole, "\005DocumentSummaryInformation")))
     {
         pWB->docSummary = calloc(1, 4096);
+        if (pWB->docSummary == NULL) {
+            retval = LIBXLS_ERROR_MALLOC;
+            goto cleanup;
+        }
 		if (ole2_read(pWB->docSummary, 4096, 1, pWB->olestr) == -1) {
             if (xls_debug) fprintf(stderr, "DocumentSummaryInformation not found\n");
             retval = LIBXLS_ERROR_READ;
@@ -1503,6 +1530,10 @@ static xlsWorkBook *xls_open_ole(OLE2 *ole, const char *charset, xls_error_t *ou
     pWB->xfs.count=0;
     pWB->fonts.count=0;
     pWB->charset = strdup(charset ? charset : "UTF-8");
+    if (pWB->charset == NULL) {
+        retval = LIBXLS_ERROR_MALLOC;
+        goto cleanup;
+    }
 
     retval = xls_parseWorkBook(pWB);
 
@@ -1604,8 +1635,10 @@ void xls_close_WB(xlsWorkBook* pWB)
     // SST
     {
         DWORD i;
-        for(i=0; i<pWB->sst.count; ++i) {
-            free(pWB->sst.string[i].str);
+        if (pWB->sst.string) {
+            for(i=0; i<pWB->sst.count; ++i) {
+                free(pWB->sst.string[i].str);
+            }
         }
         free(pWB->sst.string);
     }
@@ -1659,8 +1692,10 @@ void xls_close_WS(xlsWorkSheet* pWS)
         DWORD i, j;
         for(j=0; j<=pWS->rows.lastrow; ++j) {
             struct st_row_data *row = &pWS->rows.row[j];
-            for(i=0; i<row->cells.count; ++i) {
-                free(row->cells.cell[i].str);
+            if (row->cells.cell) {
+                for(i=0; i<row->cells.count; ++i) {
+                    free(row->cells.cell[i].str);
+                }
             }
             free(row->cells.cell);
         }

--- a/src/xlstool.c
+++ b/src/xlstool.c
@@ -260,6 +260,9 @@ static char *unicode_decode_wcstombs(const char *s, size_t len, xls_locale_t loc
     wchar_t *w = NULL;
 
     w = malloc((len/2+1)*sizeof(wchar_t));
+    if (w == NULL) {
+        goto cleanup;
+    }
 
     for(i=0; i<len/2; i++)
     {
@@ -274,6 +277,9 @@ static char *unicode_decode_wcstombs(const char *s, size_t len, xls_locale_t loc
     }
 
     converted = calloc(count+1, sizeof(char));
+    if (converted == NULL) {
+        goto cleanup;
+    }
     count2 = xls_wcstombs_l(converted, w, count, locale);
     if (count2 <= 0) {
         printf("wcstombs failed (%lu)\n", (unsigned long)len/2);
@@ -299,6 +305,8 @@ static char *transcode_latin1_to_utf8(const char *str, DWORD len)
     }
 	
     char *out = ret = malloc(len+utf8_chars+1);
+    if (ret == NULL)
+        return NULL;
     // UTF-8 encoding inline
     for(i=0; i<len; ++i) {
         BYTE c = str[i];
@@ -333,6 +341,8 @@ char* codepage_decode(const char *s, size_t len, xlsWorkBook *pWB) {
     return unicode_decode_iconv(s, len, pWB->converter);
 #else
     char *ret = malloc(len+1);
+    if (ret == NULL)
+        return NULL;
     memcpy(ret, s, len);
     ret[len] = 0;
     return ret;
@@ -677,6 +687,8 @@ char *xls_getfcell(xlsWorkBook* pWB, struct st_cell_data* cell, BYTE *label)
     case XLS_RECORD_RK:
     case XLS_RECORD_NUMBER:
         ret = malloc(retlen);
+        if (ret == NULL)
+            return NULL;
         snprintf(ret, retlen, "%lf", cell->d);
 		break;
 		//		if( RK || MULRK || NUMBER || FORMULA)
@@ -684,6 +696,8 @@ char *xls_getfcell(xlsWorkBook* pWB, struct st_cell_data* cell, BYTE *label)
     default:
         if (xf) {
             ret = malloc(retlen);
+            if (ret == NULL)
+                return NULL;
             switch (xf->format)
             {
                 case XLS_FORMAT_GENERAL:
@@ -738,7 +752,14 @@ char* xls_getCSS(xlsWorkBook* pWB)
 
     char *ret = malloc(65535);
     size_t buf_len = 4096;
-    char *buf = malloc(buf_len);
+    char *buf;
+    if (ret == NULL)
+        return NULL;
+    buf = malloc(buf_len);
+    if (buf == NULL) {
+        free(ret);
+        return NULL;
+    }
 	ret[0] = '\0';
 
     for (i=0;i<pWB->xfs.count;i++)
@@ -854,7 +875,11 @@ char* xls_getCSS(xlsWorkBook* pWB)
 
 		strcat(ret,buf);
     }
-	ret = realloc(ret, strlen(ret)+1);
+	{
+		char *shrunk = realloc(ret, strlen(ret)+1);
+		if (shrunk != NULL)
+			ret = shrunk;
+	}
 	free(buf);
 
     return ret;


### PR DESCRIPTION
### The main issue

Six growable struct arrays are reallocated with the `x = realloc(x, n)` idiom:

```c
pWB->fonts.font = realloc(pWB->fonts.font, (pWB->fonts.count+1)*sizeof(struct st_font_data));
if (pWB->fonts.font == NULL)
    return NULL;
```

`realloc` does not free the old block when it fails, but the assignment overwrites the pointer with `NULL` before the check runs. So on failure the old array leaks *and* `pWB->fonts.count` is left non-zero next to a `NULL` pointer. `xls_close_WB()` later does:

```c
for(i=0; i<pWB->fonts.count; ++i)
    free(pWB->fonts.font[i].name);
```

which dereferences `NULL`. The check is in the right place, it just runs one line too late to preserve the invariant. Fixed by reallocating into a temporary and only publishing it on success, in `xls_addSheet`, `xls_addFont`, `xls_addFormat`, `xls_addXF8`, `xls_addXF5` and `xls_addColinfo`.

### Related invariant breaks

- `xls_addSST` assigns the count inside the `calloc` argument list — `calloc(pWB->sst.count = sst->num, ...)` — so the count survives a failed allocation. Same shape in `xls_makeTable` for `cells.count`.
- `xls_close_WB()` / `xls_close_WS()` assumed a fully constructed object; they now tolerate a partially constructed one.
- `pWB->charset` came from an unchecked `strdup()`, and `codepage_decode()` dereferences it through `strcmp()`.

### Missing checks

Allocations that were dereferenced on the following line: `ole2_sopen`, `ole2_read_header`, `ole2_read_body` (including the unchecked `realloc` of `ole->files.file`, which had the same clobber-and-leak shape), `ole2_open_buffer`, `ole2_open_file`, `read_MSAT_body`, `xls_getWorkSheet`, `xls_open_ole` (summary and docSummary), `unicode_decode_wcstombs`, `transcode_latin1_to_utf8`, `codepage_decode`, `xls_getfcell`, `xls_getCSS`. The shrinking `realloc` at the end of `xls_getCSS` now keeps the larger buffer if it fails rather than losing it.

### How this was verified

An `LD_PRELOAD` shim fails the Nth allocation and nothing else, swept across a full parse:

```c
static int should_fail(void) { init(); return fail_at >= 0 && ++counter == fail_at; }
void *malloc(size_t n)  { if (should_fail()) return NULL; return real_malloc(n); }
void *calloc(size_t a, size_t b)  { if (should_fail()) return NULL; return real_calloc(a, b); }
void *realloc(void *p, size_t n)  { if (should_fail()) return NULL; return real_realloc(p, n); }
```

```sh
for N in $(seq 1 1500); do LD_PRELOAD=./failmalloc.so FAIL_AT=$N ./driver test/files/test2.xls; done
```

| | `dev` (9adebc9) | this branch |
|---|---|---|
| crashes, `test2.xls`, N=1..500 | 111 | 0 |
| crashes, `test2.xls`, N=1..1500 | — | 0 |
| crashes, malformed workbook from #153, N=1..300 | — | 0 |

The driver mirrors `fuzz/fuzz_xls.c` but reads its input from a file.

No behaviour change on the success path: output on `test/files/test2.xls` is byte-identical to `dev`, and `valgrind --leak-check=full` reports 0 errors and no leaks on both that file and the #153 workbook.

Tested on Debian 10, gcc 8.3, valgrind 3.14.0. This is independent of #153 itself, which I believe is already fixed on `dev` — I left the details in a comment on that issue.
