### PR TITLE
Validate font indices when generating CSS

### DIFF
--- a/src/xlstool.c
+++ b/src/xlstool.c
@@ -747,6 +747,7 @@ char* xls_getCSS(xlsWorkBook* pWB)
     WORD size;
     char fontname[255];
     struct st_xf_data* xf;
+    struct st_font_data* font;
     DWORD background;
     DWORD i;
 
@@ -765,6 +766,9 @@ char* xls_getCSS(xlsWorkBook* pWB)
     for (i=0;i<pWB->xfs.count;i++)
     {
         xf=&pWB->xfs.xf[i];
+        font = NULL;
+        if (xf->font && xf->font <= pWB->fonts.count)
+            font = &pWB->fonts.font[xf->font-1];
         switch ((xf->align & 0x70)>>4)
         {
         case 0:
@@ -839,33 +843,33 @@ char* xls_getCSS(xlsWorkBook* pWB)
             break;
         }
 
-        if (xf->font)
-            snprintf(color, sizeof(color), "color:#%.6X;",xls_getColor(pWB->fonts.font[xf->font-1].color,0));
+        if (font)
+            snprintf(color, sizeof(color), "color:#%.6X;",xls_getColor(font->color,0));
         else
             snprintf(color, sizeof(color), "%s", "");
 
-        if (xf->font && (pWB->fonts.font[xf->font-1].flag & 2))
+        if (font && (font->flag & 2))
             snprintf(italic, sizeof(italic), "font-style: italic;");
         else
             snprintf(italic, sizeof(italic), "%s", "");
 
-        if (xf->font && (pWB->fonts.font[xf->font-1].bold>400))
+        if (font && (font->bold>400))
             snprintf(bold, sizeof(bold), "font-weight: bold;");
         else
             snprintf(bold, sizeof(bold), "%s", "");
 
-        if (xf->font && (pWB->fonts.font[xf->font-1].underline))
+        if (font && font->underline)
             snprintf(underline, sizeof(underline), "text-decoration: underline;");
         else
             snprintf(underline, sizeof(underline), "%s", "");
 
-        if (xf->font)
-            size=pWB->fonts.font[xf->font-1].height/20;
+        if (font)
+            size=font->height/20;
         else
             size=10;
 
-        if (xf->font)
-            snprintf(fontname, sizeof(fontname),"%s",pWB->fonts.font[xf->font-1].name);
+        if (font && font->name)
+            snprintf(fontname, sizeof(fontname),"%s",font->name);
         else
             snprintf(fontname, sizeof(fontname),"Arial");
 


### PR DESCRIPTION
## Summary

- validate the 1-based XF font index before dereferencing the workbook font array
- reuse the validated font pointer for all CSS properties
- preserve the existing default CSS behavior for missing or invalid fonts, including a null font name

## Root cause

`xls_getCSS` treated every nonzero, file-controlled XF font index as valid and repeatedly accessed `fonts[font - 1]`. An index greater than `fonts.count` therefore caused an out-of-bounds read while generating CSS.

Fixes #161.

## Testing

- reproduced the ASAN heap-buffer-overflow on current `dev` with the reporter sample (MD5 `6788ed6006b39d6f56d96cf20618d2b1`)
- verified the same sample completes under ASAN/UBSAN with this patch
- passed a focused boundary harness covering index 0, the last valid index, one past the font count, and a valid font with a null name
- passed `make -j4 check` in a full ASAN/UBSAN build
- passed `git diff --check`